### PR TITLE
Allow cache configuration in the Forgejo Runner

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,6 +70,24 @@ forgejo_runner_allowed_valid_volumes: []
 forgejo_runner_docker_endpoint_is_unix_socket: true
 forgejo_runner_docker_endpoint: unix:///var/run/docker.sock
 
+# Whether to enable caching for CI runs, to save and restore commonly used
+# files (built dependencies, assets...)
+# For more details see the "Cache configuration" option here:
+#
+# - https://forgejo.org/docs/latest/admin/actions/runner-installation/#cache-configuration
+
+forgejo_runner_cache_enabled: false
+# The port bound by the internal cache server. 0 uses a random available port.
+forgejo_runner_cache_port: 0
+# The directory (on the container) where to store cache data.
+# Map this to a volume for persistent storage.
+# If unset, saves the results to $HOME/.cache/actcache.
+forgejo_runner_cache_directory: ""
+# The host to connect to for caching.
+# Leave empty to spawn a server automatically.
+# If set, the URL must end with '/'.
+forgejo_runner_cache_host: ""
+
 # A list of additional container networks that the container would be connected to.
 # The role does not create these networks, so make sure they already exist.
 # Use this to expose this container to another reverse proxy, which runs in a different container network.

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -41,27 +41,27 @@ runner:
 
 cache:
   # Enable cache server to use actions/cache.
-  enabled: false
+  enabled: {{ forgejo_runner_cache_enabled }}
   # The directory to store the cache data.
   # If it's empty, the cache data will be stored in $HOME/.cache/actcache.
-  dir: ""
+  dir: "{{ forgejo_runner_cache_directory }}"
   # The host of the cache server.
   # It's not for the address to listen, but the address to connect from job containers.
   # So 0.0.0.0 is a bad choice, leave it empty to detect automatically.
   host: ""
   # The port of the cache server.
   # 0 means to use a random available port.
-  port: 0
+  port: {{ forgejo_runner_cache_port }}
   # The external cache server URL. Valid only when enable is true.
   # If it's specified, act_runner will use this URL as the ACTIONS_CACHE_URL rather than start a server by itself.
   # The URL should generally end with "/".
-  external_server: ""
+  external_server: "{{ forgejo_runner_cache_host }}"
 
 container:
   # Specifies the network to which the container will connect.
   # Could be host, bridge or the name of a custom network.
   # If it's empty, create a network automatically.
-  network: ""
+  network: "{{ forgejo_runner_container_network }}"
   # Whether to create networks with IPv6 enabled. Requires the Docker daemon to be set up accordingly.
   # Only takes effect if "network" is set to "".
   enable_ipv6: false


### PR DESCRIPTION
This also required setting the network for the CI containers, or they wouldn't be able to connect to the cache server.

Fixes mother-of-all-self-hosting/mash-playbook#940.