### PR TITLE
Fix config path issue and make use of new way of registering (token + uuid)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -104,17 +104,24 @@ forgejo_runner_container_cleanup_command: |
   echo "Failed to remove stale container {{ forgejo_runner_identifier }} after {{ forgejo_runner_container_cleanup_timeout_seconds }} attempts" >&2;
   exit 1
 
-# The runner name.
-forgejo_runner_runner_name: ""
-
 # The instance URL.
 forgejo_runner_instance_url: ""
 
-# The registration token.
+# The name of the connection, as it will appear under `server.connections`
+# in the Forgejo Runner configuration file. Purely cosmetic.
+forgejo_runner_connection_name: "{{ forgejo_runner_identifier }}"
+
+# The connection's UUID and token, used to authenticate against the Forgejo
+# instance. These are declared directly in the runner's configuration file
+# (under `server.connections`), rather than being passed to the deprecated
+# `forgejo-runner register` command.
 #
-# This should be obtained via Forgejo's web interface, under:
+# Both values are obtained via Forgejo's web interface, under:
 #
 #   Site Administration -> Actions -> Runners -> Create new runner
+#
+# (or the equivalent page at the organization/user/repository level)
+forgejo_runner_connection_uuid: ""
 forgejo_runner_registration_token: ""
 
 # How many concurrent tasks should be executed simultaneously.

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -29,7 +29,7 @@
 - name: Ensure Forgejo Runner configuration file installed
   ansible.builtin.copy:
     content: "{{ forgejo_runner_configuration | to_nice_yaml(indent=2, width=999999) }}"
-    dest: "{{ forgejo_runner_base_path }}/config.yaml"
+    dest: "{{ forgejo_runner_config_path }}/config.yaml"
     mode: "0640"
     owner: "{{ forgejo_runner_uid }}"
     group: "{{ forgejo_runner_gid }}"

--- a/tasks/validate_config.yml
+++ b/tasks/validate_config.yml
@@ -29,7 +29,7 @@
     - forgejo_runner_gid
     - forgejo_runner_container_network
     - forgejo_runner_docker_endpoint
-    - forgejo_runner_runner_name
     - forgejo_runner_instance_url
+    - forgejo_runner_connection_uuid
     - forgejo_runner_registration_token
     - forgejo_runner_capacity

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -47,9 +47,14 @@ runner:
 
 server:
   # A map of connections to one or more Forgejo instances.
+  #
   # See https://forgejo.org/docs/latest/admin/actions/registration/ for how
-  # to obtain the `uuid` and `token` values (via "Create new runner" in the
-  # web UI).
+  # to obtain the `uuid` and `token` values.
+  #
+  # It is possible to obtain them via "Create new runner" in the web UI.
+  #
+  # Alternatively, if you run the Forgejo instance by yourself, it is possible
+  # to use Forgejo's command line utility to register the runner with the instance.
   connections:
     {{ forgejo_runner_connection_name }}:
       url: "{{ forgejo_runner_instance_url }}"

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -45,6 +45,17 @@ runner:
   labels:
     {{ forgejo_runner_labels }}
 
+server:
+  # A map of connections to one or more Forgejo instances.
+  # See https://forgejo.org/docs/latest/admin/actions/registration/ for how
+  # to obtain the `uuid` and `token` values (via "Create new runner" in the
+  # web UI).
+  connections:
+    {{ forgejo_runner_connection_name }}:
+      url: "{{ forgejo_runner_instance_url }}"
+      uuid: "{{ forgejo_runner_connection_uuid }}"
+      token: "{{ forgejo_runner_registration_token }}"
+
 cache:
   # Enable cache server to use actions/cache.
   enabled: {{ forgejo_runner_cache_enabled }}

--- a/templates/systemd/forgejo-runner.service.j2
+++ b/templates/systemd/forgejo-runner.service.j2
@@ -24,29 +24,6 @@ Type=simple
 Environment="HOME={{ devture_systemd_docker_base_systemd_unit_home_path }}"
 ExecStartPre={{ devture_systemd_docker_base_host_command_sh }} -c '{{ forgejo_runner_container_cleanup_command | trim | replace("\n", " ") }}'
 
-ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '[ ! -f {{ forgejo_runner_config_path }}/.runner ] && \
-      {{ devture_systemd_docker_base_host_command_docker }} run \
-      --rm \
-      --log-driver=none \
-      --user={{ forgejo_runner_uid }}:{{ forgejo_runner_gid }} \
-      --read-only \
-      --network={{ forgejo_runner_container_network }} \
-      --mount type=bind,src={{ forgejo_runner_config_path }},dst=/data \
-      {% for volume in forgejo_runner_container_additional_volumes %}
-      --mount type={{ volume.type | default('bind' if '/' in volume.src else 'volume') }},src={{ volume.src }},dst={{ volume.dst }}{{ (',' + volume.options) if volume.options | default('') else '' }} \
-      {% endfor %}
-      --tmpfs=/tmp:rw,noexec,nosuid,size={{ forgejo_runner_container_tmpfs_tmp_size }} \
-      {% for arg in forgejo_runner_container_extra_arguments %}
-      {{ arg }} \
-      {% endfor %}
-      {{ forgejo_runner_container_image }} \
-      forgejo-runner register \
-      --no-interactive \
-      --name {{ forgejo_runner_runner_name }} \
-      --instance {{ forgejo_runner_instance_url }} \
-      --token {{ forgejo_runner_registration_token }} \
-      --config /data/config.yaml'
-
 ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
       --rm \
       --name={{ forgejo_runner_identifier }} \


### PR DESCRIPTION
First off a disclaimer: I used claude code for this MR. But I'm a software developer and tried to verify the changes. This is written by myself. This is no automated PR.

# The issue
I tried to set up a runner a few days ago and failed. For that I used this role with the MASH project.

## First Error — Config Path
After running the playbook the runner was not up. A quick look in the logs revealed that it couldn't find the config file. So I figured out where it should be and moved it there.

## Second Error — Runner Registration
Next up the runner could not register. What it showed in the logs made it not entirely clear why. It only said the method of authentication is deprecated. I did not understand that immediately as unsupported. Claude code now went on a search and found the new way of registering a runner. With UUID and Token. So it made the changes and I tested it. Registration was successful.

# Potential Problems
For me as a new user this works fine. What I cannot know is the impact to existing users. Is it a braking change? Do they have to register their runners again? Is there a way to keep existing runners working and use the new flow only for newly registered runners?